### PR TITLE
hating on gradle is essential to the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,8 @@ version = mod_version
 group = mod_group_id
 
 repositories {
-    // Add here additional repositories if required by some of the dependencies below.
+    maven { url = "https://maven.terraformersmc.com/" } // EMI
+    maven { url = "https://api.modrinth.com/maven" } // Databank, Halcyon, Tempad
 }
 
 base {
@@ -88,35 +89,14 @@ configurations {
 }
 
 dependencies {
-    // Specify the version of Minecraft to use.
-    // Depending on the plugin applied there are several options. We will assume you applied the userdev plugin as shown above.
-    // The group for userdev is net.neoforged, the module name is neoforge, and the version is the same as the neoforge version.
-    // You can however also use the vanilla plugin (net.neoforged.gradle.vanilla) to use a version of Minecraft without the neoforge loader.
-    // And its provides the option to then use net.minecraft as the group, and one of; client, server or joined as the module name, plus the game version as version.
-    // For all intends and purposes: You can treat this dependency as if it is a normal library you would use.
     implementation "net.neoforged:neoforge:${neo_version}"
 
-    // Example optional mod dependency with JEI
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    // compileOnly "mezz.jei:jei-${mc_version}-common-api:${jei_version}"
-    // compileOnly "mezz.jei:jei-${mc_version}-neoforge-api:${jei_version}"
-    // We add the full version to localRuntime, not runtimeOnly, so that we do not publish a dependency on it
-    // localRuntime "mezz.jei:jei-${mc_version}-neoforge:${jei_version}"
+    implementation "maven.modrinth:databank:${databank_version}"
+    implementation "maven.modrinth:data-essence:${halcyon_version}+${halcyon_suffix}"
+    implementation "maven.modrinth:tempad:${tempad_version}"
 
-    // Example mod dependency using a mod jar from ./libs with a flat dir repository
-    // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
-    // The group id is ignored when searching -- in this case, it is "blank"
-    // implementation "blank:coolmod-${mc_version}:${coolmod_version}"
-
-    // Example mod dependency using a file as dependency
-    // implementation files("libs/coolmod-${mc_version}-${coolmod_version}.jar")
-
-    // Example project dependency using a sister or child project:
-    // implementation project(":myproject")
-
-    // For more info:
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
+    compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
+    localRuntime "dev.emi:emi-neoforge:${emi_version}"
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.
@@ -133,6 +113,8 @@ tasks.withType(ProcessResources).configureEach {
             mod_name               : mod_name,
             mod_license            : mod_license,
             mod_version            : mod_version,
+            halcyon_version        : halcyon_version,
+            tempad_version         : tempad_version,
     ]
     inputs.properties replaceProperties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,11 @@ mod_version=1.0.0
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
 mod_group_id=com.egassy.htimes
+
+# Dependencies
+databank_version=1.3.0
+emi_version=1.1.22+1.21.1
+halcyon_version=0.2.12
+# modrinth moment
+halcyon_suffix=song-of-the-factory
+tempad_version=3.0.4

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -29,12 +29,12 @@ side="BOTH"
 
 [[dependencies.htimes]]
 modId="datanessence"
-versionRange="[1.0.0-alpha-song_of_the_factory2,]"
+versionRange="[${halcyon_version},)"
 ordering="AFTER"
 side="BOTH"
 
 [[dependencies.htimes]]
 modId="tempad"
-versionRange="[3.0.0,]"
+versionRange="[${tempad_version},)"
 ordering="AFTER"
 side="BOTH"


### PR DESCRIPTION
This sets up the buildscript with actual dependency grabbing. Supposedly.